### PR TITLE
Updating Dockerfile with CSC requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     yq \
     curl \
     libcurl4-openssl-dev \
+    gir1.2-harfbuzz-0.0 \
+    libfribidi-dev \
+    libgraphite2-dev \
+    libharfbuzz-dev \
+    libharfbuzz-gobject0 \
+    libharfbuzz-icu0 \
     libgit2-dev \
     libssl-dev \
+    libtiff5-dev \
     libxml2-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Overview of changes

We're getting a fail on one of the dashboards when using the new deployment script, which looks like it's down to a dependency not installing. The problem one looks like **libtiff5-dev**, but I've also added a bunch of others that were getting installed during the workflow (with the idea of making it more efficient in future).

Here's the failed workflow:

https://github.com/dfe-analytical-services/CSC_outcomes_and_enablers/actions/runs/12933475471/job/36072172135

## Why are these changes being made?

<!-- Explicitly state the reason for the pull request -->

## Checklist

<!-- Customise this checklist based on expectations for your repository -->

- [ ] I have tested these changes locally using `shinytest2::test_app()`<!-- replace with your specific automated test command if different -->
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

<!-- Put any specific questions or instructions for reviewers in here -->