### PR TITLE
Update Dockerfile with libuv1-dev for use by the fs package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && \
     libcairo2-dev \
     libglpk-dev \
     libabsl-dev \
+    libuv1-dev \
     pandoc && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Overview of changes

The pipeline is failing for the Schhol Scorecards app. This is down to a dependency being missing for the fs package: libuv.

I'm just adding this (libuv1-dev) to the docker file to get it installed on the docker image.


## Why are these changes being made?

Allow deploy scripts to run with fs as a package

## Checklist

<!-- Customise this checklist based on expectations for your repository -->

- [x] I have tested these changes locally using automated tests <!-- replace with your specific automated test command e.g. `shinytest2::test_app()` -->
- [x] I have updated the documentation
- [x] I have added or updated automated tests for these changes

## Reviewer instructions

